### PR TITLE
docs: Tradução do artigo Inverso Multiplicativo Modular

### DIFF
--- a/src/algebra/module-inverse.md
+++ b/src/algebra/module-inverse.md
@@ -9,7 +9,7 @@ e_maxx_link: reverse_element
 ## Definição
 
 Um [inverso multiplicativo modular](http://en.wikipedia.org/wiki/Modular_multiplicative_inverse) de um inteiro $a$ é um inteiro $x$ tal que $a \cdot x$ é congruente a $1$ módulo $m$.
-Para escrever de forma formal: queremos encontrar um inteiro $x$ tal que
+Para escrever formalmente: queremos encontrar um inteiro $x$ tal que
 
 $$a \cdot x \equiv 1 \mod m.$$
 

--- a/src/algebra/module-inverse.md
+++ b/src/algebra/module-inverse.md
@@ -4,40 +4,40 @@ tags:
 e_maxx_link: reverse_element
 ---
 
-# Modular Multiplicative Inverse
+# Inverso Multiplicativo Modular
 
-## Definition
+## Definição
 
-A [modular multiplicative inverse](http://en.wikipedia.org/wiki/Modular_multiplicative_inverse) of an integer $a$ is an integer $x$ such that $a \cdot x$ is congruent to $1$ modular some modulus $m$.
-To write it in a formal way: we want to find an integer $x$ so that 
+Um [inverso multiplicativo modular](http://en.wikipedia.org/wiki/Modular_multiplicative_inverse) de um inteiro $a$ é um inteiro $x$ tal que $a \cdot x$ é congruente a $1$ módulo algum $m$.
+Para escrever de forma formal: queremos encontrar um inteiro $x$ tal que
 
 $$a \cdot x \equiv 1 \mod m.$$
 
-We will also denote $x$ simply with $a^{-1}$.
+Também denotaremos $x$ simplesmente como $a^{-1}$.
 
-We should note that the modular inverse does not always exist. For example, let $m = 4$, $a = 2$. 
-By checking all possible values modulo $m$, it should become clear that we cannot find $a^{-1}$ satisfying the above equation. 
-It can be proven that the modular inverse exists if and only if $a$ and $m$ are relatively prime (i.e. $\gcd(a, m) = 1$).
+Devemos notar que o inverso modular nem sempre existe. Por exemplo, seja $m = 4$, $a = 2$.
+Ao testar todos os valores possíveis módulo $m$, deve ficar claro que não podemos encontrar um $a^{-1}$ que satisfaça a equação acima.
+Pode ser provado que o inverso modular existe se e somente se $a$ e $m$ forem primos entre si (ou seja, coprimos, $\gcd(a, m) = 1$).
 
-In this article, we present two methods for finding the modular inverse in case it exists, and one method for finding the modular inverse for all numbers in linear time.
+Neste artigo, apresentamos dois métodos para encontrar o inverso modular caso ele exista, e um método para encontrar o inverso modular para todos os números em tempo linear.
 
-## Finding the Modular Inverse using Extended Euclidean algorithm
+## Encontrando o Inverso Modular usando o Algoritmo de Euclides Estendido
 
-Consider the following equation (with unknown $x$ and $y$):
+Considere a seguinte equação (com incógnitas $x$ e $y$):
 
 $$a \cdot x + m \cdot y = 1$$
 
-This is a [Linear Diophantine equation in two variables](linear-diophantine-equation.md).
-As shown in the linked article, when $\gcd(a, m) = 1$, the equation has a solution which can be found using the [extended Euclidean algorithm](extended-euclid-algorithm.md).
-Note that $\gcd(a, m) = 1$ is also the condition for the modular inverse to exist.
+Essa é uma [Equação Diofantina Linear de duas variáveis](linear-diophantine-equation.md).
+Como mostrado no artigo mencionado, quando $\gcd(a, m) = 1$, a equação tem uma solução que pode ser encontrada usando o [algoritmo de Euclides estendido](extended-euclid-algorithm.md).
+Note que $\gcd(a, m) = 1$ também é a condição para que o inverso modular exista.
 
-Now, if we take modulo $m$ of both sides, we can get rid of $m \cdot y$, and the equation becomes:
+Agora, se tirarmos o módulo $m$ de ambos os lados, podemos nos livrar de $m \cdot y$, e a equação se torna:
 
 $$a \cdot x \equiv 1 \mod m$$
 
-Thus, the modular inverse of $a$ is $x$.
+Portanto, o inverso modular de $a$ é $x$.
 
-The implementation is as follows:
+A implementação é a seguinte:
 
 ```cpp
 int x, y;
@@ -51,40 +51,40 @@ else {
 }
 ```
 
-Notice that the way we modify `x`.
-The resulting `x` from the extended Euclidean algorithm may be negative, so `x % m` might also be negative, and we first have to add `m` to make it positive.
+Observe a forma como modificamos `x`.
+O `x` resultante do algoritmo de Euclides estendido pode ser negativo, logo, `x % m` também pode ser negativo, e primeiro temos que somar `m` para torná-lo positivo.
 
 <div id="fermat-euler"></div>
-## Finding the Modular Inverse using Binary Exponentiation
+## Encontrando o Inverso Modular usando Exponenciação Binária
 
-Another method for finding modular inverse is to use Euler's theorem, which states that the following congruence is true if $a$ and $m$ are relatively prime:
+Outro método para encontrar o inverso modular é utilizar o teorema de Euler, que afirma que a seguinte congruência é verdadeira se $a$ e $m$ forem primos entre si:
 
 $$a^{\phi (m)} \equiv 1 \mod m$$
 
-$\phi$ is [Euler's Totient function](phi-function.md).
-Again, note that $a$ and $m$ being relative prime was also the condition for the modular inverse to exist.
+$\phi$ é a [Função Totiente de Euler](phi-function.md).
+Mais uma vez, note que $a$ e $m$ serem primos entre si também era a condição para a existência do inverso modular.
 
-If $m$ is a prime number, this simplifies to [Fermat's little theorem](http://en.wikipedia.org/wiki/Fermat's_little_theorem):
+Se $m$ for um número primo, isso se simplifica para o [Pequeno teorema de Fermat](http://en.wikipedia.org/wiki/Fermat's_little_theorem):
 
 $$a^{m - 1} \equiv 1 \mod m$$
 
-Multiply both sides of the above equations by $a^{-1}$, and we get:
+Multiplique ambos os lados das equações acima por $a^{-1}$ e obtemos:
 
-* For an arbitrary (but coprime) modulus $m$: $a ^ {\phi (m) - 1} \equiv a ^{-1} \mod m$
-* For a prime modulus $m$: $a ^ {m - 2} \equiv a ^ {-1} \mod m$
+* Para um módulo $m$ arbitrário (porém coprimo): $a ^ {\phi (m) - 1} \equiv a ^{-1} \mod m$
+* Para um módulo $m$ primo: $a ^ {m - 2} \equiv a ^ {-1} \mod m$
 
-From these results, we can easily find the modular inverse using the [binary exponentiation algorithm](binary-exp.md), which works in $O(\log m)$ time.
+A partir desses resultados, podemos encontrar facilmente o inverso modular usando o [algoritmo de exponenciação binária](binary-exp.md), que roda em tempo $O(\log m)$.
 
-Even though this method is easier to understand than the method described in previous paragraph, in the case when $m$ is not a prime number, we need to calculate Euler phi function, which involves factorization of $m$, which might be very hard. If the prime factorization of $m$ is known, then the complexity of this method is $O(\log m)$.
+Apesar desse método ser mais fácil de entender do que o método descrito no parágrafo anterior, no caso de $m$ não ser um número primo, precisamos calcular a função totiente de Euler, o que envolve a fatoração de $m$, que pode ser bastante custosa. Se a fatoração prima de $m$ for conhecida, a complexidade desse método é $O(\log m)$.
 
 <div id="finding-the-modular-inverse-using-euclidean-division"></div>
-## Finding the modular inverse for prime moduli using Euclidean Division
+## Encontrando o inverso modular para módulos primos usando Divisão Euclidiana
 
-Given a prime modulus $m > a$ (or we can apply modulo to make it smaller in 1 step), according to [Euclidean Division](https://en.wikipedia.org/wiki/Euclidean_division)
+Dado um módulo primo $m > a$ (ou podemos aplicar o módulo para torná-lo menor em 1 passo), de acordo com a [Divisão Euclidiana](https://en.wikipedia.org/wiki/Euclidean_division)
 
 $$m = k \cdot a + r$$
 
-where $k = \left\lfloor \frac{m}{a} \right\rfloor$ and $r = m \bmod a$, then
+onde $k = \left\lfloor \frac{m}{a} \right\rfloor$ e $r = m \bmod a$, então
 
 $$
 \begin{align*}
@@ -95,11 +95,11 @@ $$
 \end{align*}
 $$
 
-Note that this reasoning does not hold if $m$ is not prime, since the existence of $a^{-1}$ does not imply the existence of $r^{-1}$
-in the general case. To see this, lets try to calculate $5^{-1}$ modulo $12$ with the above formula. We would like to arrive at $5$,
-since $5 \cdot 5 \equiv 1 \bmod 12$. However, $12 = 2 \cdot 5 + 2$, and we have $k=2$ and $r=2$, with $2$ being not invertible modulo $12$.
+Note que esse raciocínio não se mantém se $m$ não for primo, já que a existência de $a^{-1}$ não implica a existência de $r^{-1}$
+no caso geral. Para notar isso, vamos tentar calcular $5^{-1}$ módulo $12$ com a fórmula acima. Gostaríamos de chegar a $5$,
+já que $5 \cdot 5 \equiv 1 \bmod 12$. Porém, $12 = 2 \cdot 5 + 2$, logo temos $k=2$ e $r=2$, em que $2$ não é invertível módulo $12$.
 
-If the modulus is prime however, all $a$ with $0 < a < m$ are invertible modulo $m$, and we can have the following recursive function (in C++) for computing the modular inverse for number $a$ with respect to $m$
+Contudo, se o módulo for primo, todos os $a$ tal que $0 < a < m$ são invertíveis módulo $m$, e podemos ter a seguinte função recursiva (em C++) para calcular o inverso modular para o número $a$ em relação a $m$:
 
 ```{.cpp file=modular_inverse_euclidean_division}
 int inv(int a) {
@@ -107,12 +107,12 @@ int inv(int a) {
 }
 ```
 
-The exact time complexity of the this recursion is not known. It's is somewhere between $O(\frac{\log m}{\log\log m})$ and $O(m^{\frac{1}{3} - \frac{2}{177} + \epsilon})$.
-See [On the length of Pierce expansions](https://arxiv.org/abs/2211.08374).
-In practice this implementation is fast, e.g. for the modulus $10^9 + 7$ it will always finish in less than 50 iterations.
+A complexidade de tempo exata dessa recursão não é conhecida. Estima-se que seja algo entre $O(\frac{\log m}{\log\log m})$ e $O(m^{\frac{1}{3} - \frac{2}{177} + \epsilon})$.
+Veja [Sobre a extensão de expansões de Pierce](https://arxiv.org/abs/2211.08374).
+Na prática, essa implementação é rápida; por exemplo, para o módulo $10^9 + 7$, ela sempre terminará em menos de 50 iterações.
 
 <div id="mod-inv-all-num"></div>
-Applying this formula, we can also precompute the modular inverse for every number in the range $[1, m-1]$ in $O(m)$.
+Aplicando essa fórmula, também podemos pré-calcular o inverso modular para todos os números no intervalo $[1, m-1]$ em $O(m)$.
 
 ```{.cpp file=modular_inverse_euclidean_division_all}
 inv[1] = 1;
@@ -120,10 +120,10 @@ for(int a = 2; a < m; ++a)
     inv[a] = m - (long long)(m/a) * inv[m%a] % m;
 ```
 
-## Finding the modular inverse for array of numbers modulo $m$
+## Encontrando o inverso modular para um array de números módulo $m$
 
-Suppose we are given an array and we want to find modular inverse for all numbers in it (all of them are invertible).
-Instead of computing the inverse for every number, we can expand the fraction by the prefix product (excluding itself) and suffix product (excluding itself), and end up only computing a single inverse instead.
+Suponha que tenhamos um array e queremos encontrar o inverso modular para todos os números dele (sendo todos invertíveis).
+Em vez de calcular o inverso para cada número, podemos expandir a fração pelo produto de prefixo (excluindo a si próprio) e pelo produto de sufixo (excluindo a si próprio), terminando com o cálculo de apenas um único inverso.
 
 $$
 \begin{align}
@@ -132,8 +132,8 @@ x_i^{-1} &= \frac{1}{x_i} = \frac{\overbrace{x_1 \cdot x_2 \cdots x_{i-1}}^{\tex
 \end{align}
 $$
 
-In the code we can just make a prefix product array (exclude itself, start from the identity element), compute the modular inverse for the product of all numbers and then multiply it by the prefix product and suffix product (exclude itself).
-The suffix product is computed by iterating from the back to the front.
+No código, podemos apenas construir um array com produtos de prefixo (excluindo a si próprio e iniciando do elemento de identidade), calcular o inverso modular do produto de todos os números e então multiplicá-lo pelo produto de prefixo e o produto de sufixo (excluindo a si próprio).
+O produto de sufixo é computado iterando de trás para frente.
 
 ```cpp
 std::vector<int> invs(const std::vector<int> &a, int m) {
@@ -156,7 +156,7 @@ std::vector<int> invs(const std::vector<int> &a, int m) {
 }
 ```
 
-## Practice Problems
+## Problemas Práticos
 
 * [UVa 11904 - One Unit Machine](https://uva.onlinejudge.org/index.php?option=com_onlinejudge&Itemid=8&page=show_problem&problem=3055)
 * [Hackerrank - Longest Increasing Subsequence Arrays](https://www.hackerrank.com/contests/world-codesprint-5/challenges/longest-increasing-subsequence-arrays)

--- a/src/algebra/module-inverse.md
+++ b/src/algebra/module-inverse.md
@@ -108,7 +108,7 @@ int inv(int a) {
 ```
 
 A complexidade de tempo exata dessa recursão não é conhecida. Estima-se que seja algo entre $O(\frac{\log m}{\log\log m})$ e $O(m^{\frac{1}{3} - \frac{2}{177} + \epsilon})$.
-Veja [Sobre a extensão de expansões de Pierce](https://arxiv.org/abs/2211.08374).
+Veja [Sobre o comprimento das expansões de Pierce](https://arxiv.org/abs/2211.08374).
 Na prática, essa implementação é rápida; por exemplo, para o módulo $10^9 + 7$, ela sempre terminará em menos de 50 iterações.
 
 <div id="mod-inv-all-num"></div>

--- a/src/algebra/module-inverse.md
+++ b/src/algebra/module-inverse.md
@@ -8,7 +8,7 @@ e_maxx_link: reverse_element
 
 ## Definição
 
-Um [inverso multiplicativo modular](http://en.wikipedia.org/wiki/Modular_multiplicative_inverse) de um inteiro $a$ é um inteiro $x$ tal que $a \cdot x$ é congruente a $1$ módulo algum $m$.
+Um [inverso multiplicativo modular](http://en.wikipedia.org/wiki/Modular_multiplicative_inverse) de um inteiro $a$ é um inteiro $x$ tal que $a \cdot x$ é congruente a $1$ módulo $m$.
 Para escrever de forma formal: queremos encontrar um inteiro $x$ tal que
 
 $$a \cdot x \equiv 1 \mod m.$$

--- a/src/navigation.md
+++ b/src/navigation.md
@@ -28,7 +28,7 @@ Artigos com a bandeira 🇺🇸 estão em inglês. Artigos com a bandeira 🇧�
         - [🇺🇸 Euler's totient function](algebra/phi-function.md)
         - [🇺🇸 Number of divisors / sum of divisors](algebra/divisors.md)
     - Modular arithmetic
-        - [🇺🇸 Modular Inverse](algebra/module-inverse.md)
+        - [🇧🇷 Inverso Multiplicativo Modular](algebra/module-inverse.md)
         - [🇺🇸 Linear Congruence Equation](algebra/linear_congruence_equation.md)
         - [🇺🇸 Chinese Remainder Theorem](algebra/chinese-remainder-theorem.md)
         - [🇺🇸 Garner's Algorithm](algebra/garners-algorithm.md)


### PR DESCRIPTION
This PR translates the "Modular Inverse" article to Brazilian Portuguese (PT-BR).

Steps taken:
- Translated `src/algebra/module-inverse.md` while preserving all LaTeX formulas, code snippets, and explicit HTML anchor tags (`<div id="..."></div>`).
- Updated `src/navigation.md` to reflect the new translated title and updated the emoji flag.
- Verified that other articles linking to the anchor tags inside this file are not broken, since the HTML `id` attributes were preserved.
- Built the docs using `mkdocs build` to confirm everything runs cleanly.

---
*PR created automatically by Jules for task [13409289552126769165](https://jules.google.com/task/13409289552126769165) started by @filipemsilv4*